### PR TITLE
feat(common): fixing parallel workflow

### DIFF
--- a/src/workflow-configurations/DocumentUploadConfiguration.js
+++ b/src/workflow-configurations/DocumentUploadConfiguration.js
@@ -11,8 +11,8 @@ export const DocumentUploadEditConfiguration = () => {
     const { values, setFieldValue } = useFormikContext()
 
     const options = [
-        'F24H Wizard',
-        'MadCap Flare POC'
+        'React',
+        'Java'
     ]
 
     const handleChange = (value) => {
@@ -24,7 +24,7 @@ export const DocumentUploadEditConfiguration = () => {
     return (
             <>
                 <Form.Group>
-                    <Form.Label>Select document to review</Form.Label>
+                    <Form.Label>Select deployment for approval</Form.Label>
                     <Typeahead
                     id="basic-typeahead-single"
                     name="selectedDocument"
@@ -61,7 +61,7 @@ export const DocumentUploadViewConfiguration = ({workflowId}) => {
             <>
                 <Form.Group as={Row} controlId="formPlaintextEmail">
                     <Form.Label column sm="12">
-                    Document to review
+                    Deployment for approval
                     </Form.Label>
                     <Col sm="10">
                     <Form.Control plaintext readOnly value={configuration.document} />

--- a/src/workflow/WorkflowApproval.js
+++ b/src/workflow/WorkflowApproval.js
@@ -44,7 +44,7 @@ export const WorkflowApproval = () => {
   const setWorkflowStatus = (level, value) => {
     // workflowId: id,
     // level: stage,
-    fetch("http://ec2-18-222-143-149.us-east-2.compute.amazonaws.com:8888/acknowledgement/", {
+    fetch("http://ec2-18-224-200-243.us-east-2.compute.amazonaws.com:8888/acknowledgement/", {
 
       method: "POST",
       body: JSON.stringify({

--- a/src/workflow/WorkflowCreation.js
+++ b/src/workflow/WorkflowCreation.js
@@ -55,7 +55,7 @@ export const WorkflowCreation = () => {
     const handleWorkflowSave = async (values) => {
         console.log('values', values)
 
-        const response = await fetch('http://ec2-18-222-143-149.us-east-2.compute.amazonaws.com:8888/workflow/initiate', {
+        const response = await fetch('http://ec2-18-224-200-243.us-east-2.compute.amazonaws.com:8888/workflow/initiate', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'

--- a/src/workflow/WorkflowDiagramGenerator.js
+++ b/src/workflow/WorkflowDiagramGenerator.js
@@ -19,7 +19,7 @@ export const WorkflowDiagramGenerator = ({ type, workflowId, onNodeClick, isView
   useEffect(() => {
     //get workflow information from workflowId
     const fetchWorkflow = async () => {
-        const response = await fetch(`http://ec2-18-222-143-149.us-east-2.compute.amazonaws.com:8888/workflow/history/${workflowId}`, {
+        const response = await fetch(`http://ec2-18-224-200-243.us-east-2.compute.amazonaws.com:8888/workflow/history/${workflowId}`, {
             method: 'GET'
         })
         if(response.ok){
@@ -145,13 +145,13 @@ export const WorkflowDiagramGenerator = ({ type, workflowId, onNodeClick, isView
             height: 100,
             width: 100,
             offsetX: 200,
-            offsetY: 100,
+            offsetY: 300,
             style: {
               fill: grey,
             },
             annotations: [
               {
-                content: "Step 1 - Document Selection"
+                content: "Deployment"
               },
               {
                 stepType: "documentUpload",
@@ -167,17 +167,36 @@ export const WorkflowDiagramGenerator = ({ type, workflowId, onNodeClick, isView
             height: 100,
             width: 100,
             offsetX: 400,
-            offsetY: 100,
+            offsetY: 200,
             style: {
               fill: grey,
             },
             annotations: [
               {
-                content: "Step 2 - Document Review"
+                content: "Review Step"
               },
               {
-                stepType: "multiReview",
+                stepType: "singleReview",
                 stepNumber: "two"
+              }
+            ]
+          },
+          {
+            id: "node3",
+            height: 100,
+            width: 100,
+            offsetX: 400,
+            offsetY: 400,
+            style: {
+              fill: grey,
+            },
+            annotations: [
+              {
+                content: "Review Step"
+              },
+              {
+                stepType: "singleReview",
+                stepNumber: "three"
               }
             ]
           }
@@ -187,6 +206,11 @@ export const WorkflowDiagramGenerator = ({ type, workflowId, onNodeClick, isView
             id: "connector1",
             sourceID: "node1",
             targetID: "node2"
+          },
+          {
+            id: "connector2",
+            sourceID: "node1",
+            targetID: "node3"
           }
         ]
       }
@@ -206,7 +230,7 @@ export const WorkflowDiagramGenerator = ({ type, workflowId, onNodeClick, isView
     const selectedWorkflow = workflows.filter(item => item.id !== workflowId)
     console.log('historyWithStages', historyWithStages, selectedWorkflow)
 
-    if (selectedWorkflow.length && type.toLowerCase() === 'sequential'){
+    if (selectedWorkflow.length && (type.toLowerCase() === 'sequential' || type.toLowerCase() === 'parallel')){
         if(historyWithStages && !historyWithStages.length){
             setWorkflowType({...workflowSteps})
         }
@@ -238,10 +262,7 @@ export const WorkflowDiagramGenerator = ({ type, workflowId, onNodeClick, isView
             return null
         }
       }
-    }  else if (type.toLowerCase() === 'parallel'){
-      // code for parallel view workflow status change
-      // Will implement it as soon as we get history object structure for Parallel flow
-    }
+    } 
   }, [workflowId, type, historyWithStages])
 
   return (


### PR DESCRIPTION
This fixes the parallel workflow by updating the following -

1. The parallel step now shows as two nodes one below the other both connected to the start node. This indicates parallel flow
2. In each of the parallel flow step, there is an option to choose a single reviewer right now. It can later be altered to select multiple
3. The same approval page is being used for sequential and parallel workflows

In the logic which determines the node to be marked complete (green), currently the flow remains the same. It might change later on to effectively handle same numbered steps for parallel workflow. Currently even if the workflow is parallel, the steps are uniquely numbered just like in the sequential workflow.